### PR TITLE
Update README.md to include sourcify dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,7 @@ Ikra is an array-based parallel extension to Ruby with dynamic compilation. The 
 ## Installation
 * Tested with Ruby 2.3.0
 * Run `bundle install`
+* clone sourcify lib
+* run `cd lib ; git clone https://github.com/matthias-springer/sourcify.git`
+* run `cd sourcify; bundle instal`
 * Make sure that the nVidia CUDA Toolkit is installed (check paths in `config/os_configuration.rb`)


### PR DESCRIPTION
Simply add how to get `sourcify` lib necessary for the gem 